### PR TITLE
Add HeaderPath and FooterPath in document (YAML attributes).

### DIFF
--- a/src/System/Tasks/ConversionRunner.ts
+++ b/src/System/Tasks/ConversionRunner.ts
@@ -1,6 +1,7 @@
 import Clone = require("clone");
 import { CultureInfo } from "culture-info";
 import Template = require("es6-template-string");
+import Fs = require("fs");
 import FileSystem = require("fs-extra");
 import HighlightJs = require("highlight.js");
 import MarkdownIt = require("markdown-it");
@@ -272,6 +273,34 @@ export class ConversionRunner
         let converter = new Converter(workspaceRoot, new Document(document, await this.LoadParser()));
         converter.Document.Quality = Settings.Default.ConversionQuality;
 
+        try
+        {
+            let headerPath = converter.Document.Attributes.HeaderPath;
+            if (!Path.isAbsolute(headerPath))
+            {
+                headerPath = Path.resolve(converter.WorkspaceRoot, headerPath);
+            }
+            converter.Document.Header.Content = Fs.readFileSync(headerPath, "utf8");
+        }
+        catch (err)
+        {
+            converter.Document.Header.Content = Settings.Default.HeaderTemplate;
+        }
+
+        try
+        {
+            let footerPath = converter.Document.Attributes.FooterPath;
+            if (!Path.isAbsolute(footerPath))
+            {
+                footerPath = Path.resolve(converter.WorkspaceRoot, footerPath);
+            }
+            converter.Document.Footer.Content = Fs.readFileSync(footerPath, "utf8");
+        }
+        catch
+        {
+            converter.Document.Footer.Content = Settings.Default.FooterTemplate;
+        }
+
         Object.assign(converter.Document.Attributes, Settings.Default.Attributes);
         converter.Document.Attributes.Author = converter.Document.Attributes.Author || await Utilities.GetFullName();
 
@@ -281,8 +310,6 @@ export class ConversionRunner
         converter.Document.Paper = Settings.Default.PaperFormat;
 
         converter.Document.HeaderFooterEnabled = Settings.Default.HeaderFooterEnabled;
-        converter.Document.Header.Content = Settings.Default.HeaderTemplate;
-        converter.Document.Footer.Content = Settings.Default.FooterTemplate;
 
         try
         {


### PR DESCRIPTION
Add HeaderPath and FooterPath in document (YAML attributes).
Path can be absolute or relative.
If attributes don't exist in the YAML header, header and footer templates defined in MarkdownConverter settings will be used.

#38 